### PR TITLE
README - Update sampel module config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ git clone https://github.com/Chrismarsh/spack-repo.git
 
 and then add this as the first repo as described [on Spack's readme](https://spack.readthedocs.io/en/latest/repositories.html#repos-yaml).
 
-This repo now conforms to the v2 api for Spack 1.0
+This repo now conforms to the v2 api for Spack 1.0.
+
+To use the packages defined in this repository, add the following to your user spack config under:
+`~/.spack/repos.yaml`
 
 ```
-$ cat repos.yaml
-	repos:
-	  - /Users/myuser/spack-repo
-
+repos:
+  - /Users/myuser/spack-repo/spack_repo/chm
 ```


### PR DESCRIPTION
The V2 API needs to point to the path were the `repo.yaml` is stored. Otherwise the defined packages are not recognized.

Also broke out the `cat` command out of the yaml file content. I have found that new users can struggle to with proper YAML syntax.